### PR TITLE
Add python 3.15 to CI - closes #778

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@3768ca868776ab12e78334cc376094a7aec3d9b6 # v5.3.1
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
       dependency-manager: 'uv'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/newsfragments/778.misc.rst
+++ b/newsfragments/778.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.15 to CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Added Python 3.15 to the supported versions covered by automated testing.

- **Documentation**
  - Updated the release notes to record Python 3.15 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->