### PR TITLE
Add FBT linter class to ruff configuration - closes #779

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -5,6 +5,9 @@ on:
     - cron: '12 7 5 * *'
   workflow_dispatch: {}
 
+concurrency:
+  group: release-schedule
+
 jobs:
   schedule:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-schedule
+
 jobs:
   release:
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build/
 .idea/
 __pycache__
 *.egg-info/
-Pipfile.lock
 
 # coverage
 .coverage

--- a/newsfragments/779.break.rst
+++ b/newsfragments/779.break.rst
@@ -1,0 +1,4 @@
+The `should_create` and `should_drop` arguments of `bind_engine`, and the
+`should_close` argument of `get_as_named_tempfile`, are now keyword-only.
+The `propagate`, `now`, and `save` arguments of `TouchMixin.touch` are now
+keyword-only.

--- a/newsfragments/779.misc.rst
+++ b/newsfragments/779.misc.rst
@@ -1,0 +1,1 @@
+Add FBT linter class to ruff configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,11 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E", # pycodestyle
-    "F", # pyflakes
-    "I", # isort
-    "D", # pydocstyle
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "D",   # pydocstyle
+    "FBT", # flake8-boolean-trap
 ]
 
 [tool.pyproject-fmt]

--- a/pyramid_basemodel/__init__.py
+++ b/pyramid_basemodel/__init__.py
@@ -176,6 +176,7 @@ def bind_engine(
     engine: Engine,
     session: scoped_session[Any] = Session,
     base: type[DeclarativeBase] = Base,
+    *,
     should_create: bool = False,
     should_drop: bool = False,
 ) -> None:

--- a/pyramid_basemodel/blob.py
+++ b/pyramid_basemodel/blob.py
@@ -107,7 +107,7 @@ class Blob(Base, BaseMixin):
 
         self.value = r.content
 
-    def get_as_named_tempfile(self, should_close: bool = False) -> "_TemporaryFileWrapper[bytes]":
+    def get_as_named_tempfile(self, *, should_close: bool = False) -> "_TemporaryFileWrapper[bytes]":
         """Read ``self.value`` into and return a named temporary file."""
         # Prepare the temp file.
         f = NamedTemporaryFile(delete=False)

--- a/pyramid_basemodel/mixin.py
+++ b/pyramid_basemodel/mixin.py
@@ -69,6 +69,7 @@ class TouchMixin:
 
     def touch(
         self,
+        *,
         propagate: bool = True,
         now: Callable[[], datetime] = datetime.utcnow,
         save: Callable[..., None] = save_to_db,

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -33,7 +33,7 @@ def test_touch_mixin_no_propagate() -> None:
 
     assert not hasattr(t, "modified")
     with patch.object(t, "propagate_touch") as propagate_mock:
-        t.touch(False, now=Mock, save=save_mock)
+        t.touch(propagate=False, now=Mock, save=save_mock)
         assert not propagate_mock.called
     assert hasattr(t, "modified")
     assert t == saved_arg[0]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Boolean options for engine binding, temporary-file handling and touch operations must now be provided as keyword arguments.
  - Existing positional usage of these options will need updating.

- **Chores**
  - Added Ruff’s FBT linting checks to improve code quality.
  - Release workflows now prevent overlapping release runs.

- **Documentation**
  - Added release notes describing the updated argument requirements and linting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->